### PR TITLE
TECH-3901: rename gem internal name to eb-ruby-kafka

### DIFF
--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kafka/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "ruby-kafka"
+  spec.name          = "eb-ruby-kafka"
   spec.version       = EbKafka::VERSION
   spec.authors       = ["Daniel Schierbeck"]
   spec.email         = ["daniel.schierbeck@gmail.com"]


### PR DESCRIPTION
Rename gem ruby-kafka -> eb-ruby-kafka to avoid collision with upstream gem.

EB PR has been updated.
eb-ruby-kafka and elephant_bus tests are all passing

Don't need to bump version as the version was just bumped like 15 minutes ago.